### PR TITLE
For comma-separated ExtensionReferenceFilter extensions, ignore whitespace

### DIFF
--- a/norconex-collector-core/src/main/java/com/norconex/collector/core/filter/impl/ExtensionReferenceFilter.java
+++ b/norconex-collector-core/src/main/java/com/norconex/collector/core/filter/impl/ExtensionReferenceFilter.java
@@ -105,6 +105,9 @@ public class ExtensionReferenceFilter extends AbstractOnMatchFilter implements
     public String getExtensions() {
         return extensions;
     }
+    public String[] getExtensionParts() {
+        return extensionParts;
+    }
     public boolean isCaseSensitive() {
         return caseSensitive;
     }
@@ -114,7 +117,9 @@ public class ExtensionReferenceFilter extends AbstractOnMatchFilter implements
     public final void setExtensions(String extensions) {
         this.extensions = extensions;
         if (extensions != null) {
-            this.extensionParts = extensions.split(",");
+            this.extensionParts = extensions.split("\\s*,\\s*");
+            for (int i = 0; i < this.extensionParts.length; i++)
+                this.extensionParts[i] = this.extensionParts[i].trim();
         } else {
             this.extensionParts = ArrayUtils.EMPTY_STRING_ARRAY;
         }

--- a/norconex-collector-core/src/test/java/com/norconex/collector/core/filter/impl/ExtensionReferenceFilterTest.java
+++ b/norconex-collector-core/src/test/java/com/norconex/collector/core/filter/impl/ExtensionReferenceFilterTest.java
@@ -1,0 +1,29 @@
+package com.norconex.collector.core.filter.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExtensionReferenceFilterTest {
+
+    @Test
+    public void testExtensionSplitting() {
+        ExtensionReferenceFilter filter = initFilter(
+                "html,htm,\n"
+              + "  xhtml , dhtml \n\n");
+
+        Assert.assertArrayEquals(
+                new String[] {
+                    "html",
+                    "htm",
+                    "xhtml",
+                    "dhtml"
+                },
+                filter.getExtensionParts());
+    }
+
+    private ExtensionReferenceFilter initFilter(String extensions) {
+        ExtensionReferenceFilter filter = new ExtensionReferenceFilter();
+        filter.setExtensions(extensions);
+        return filter;
+    }
+}


### PR DESCRIPTION
This brings parsing of the ExtensionReferenceFilter configuration in line
with e.g. GenericMetadataChecksummer or MD5DocumentChecksummer, where
whitespace is also ignored.

Turns a config like this:

``` xml
  <referenceFilters>
    <filter
      class="${filterExtension}"
      onMatch="exclude"
      caseSensitive="false"
    >3dm,3g2,3gp,7z,8bi,ai,aif,app,asf,asx,avi,bak,bat,bin,bmp,c,cab,cfg,cgi,class,cpl,cpp,cs,cur,dbx,deb,dll,dmg,dmp,drv,drw,dtd,dwg,dxf,eps,exe,fla,flv,fnt,fon,gadget,gam,gho,gif,gpx,gz,hqx,iff,indd,ini,iso,jar,java,jpg,keychain,kml,lnk,m,m3u,m4a,max,mid,mim,mov,mp3,mp4,mpa,mpg,msi,nes,ori,otf,part,pct,pif,pkg,pl,plugin,png,prf,ps,psd,pspimage,py,qxd,qxp,ra,rar,rels,rm,rom,rpm,sav,sit,sitx,svg,swf,sys,thm,tif,tmp,toast,torrent,ttf,uue,vb,vcd,vob,wav,wma,wmv,wsf,xll,yuv,zip,zipx</filter>
  </referenceFilters>
```

Into this:

``` xml
  <referenceFilters>
    <filter
      class="${filterExtension}"
      onMatch="exclude"
      caseSensitive="false"
    >
      3dm,
      3g2,
      3gp,
      7z,
      8bi,
      ai,
      aif,
      app,
      asf,
      asx,
      avi,
      […]
    </filter>
  </referenceFilters>
```
