### PR TITLE
[Bugfix] When checking references for file extensions, only consider extensions at the end of the reference

### DIFF
--- a/norconex-collector-core/src/main/java/com/norconex/collector/core/filter/impl/ExtensionReferenceFilter.java
+++ b/norconex-collector-core/src/main/java/com/norconex/collector/core/filter/impl/ExtensionReferenceFilter.java
@@ -18,6 +18,12 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -86,9 +92,25 @@ public class ExtensionReferenceFilter extends AbstractOnMatchFilter implements
         if (StringUtils.isBlank(extensions)) {
             return getOnMatch() == OnMatch.INCLUDE;
         }
-        String refExtension = reference.replaceFirst("(.*\\.)(.*?)", "$2");
-        for (int i = 0; i < extensionParts.length; i++) {
-            String ext = extensionParts[i];
+
+        String referencePath;
+        try {
+            URL referenceUrl = new URL(reference);
+            referencePath = referenceUrl.getPath();
+        } catch (MalformedURLException ex) {
+            referencePath = "";
+        }
+
+        Pattern refExtensionPattern = Pattern.compile("\\.([a-z0-9.]+)\\z", Pattern.CASE_INSENSITIVE);
+        Matcher refExtensionMatcher = refExtensionPattern.matcher(referencePath);
+        String refExtension;
+        if (refExtensionMatcher.find()) {
+            refExtension = refExtensionMatcher.group(1);
+        } else {
+            refExtension = "";
+        }
+
+        for (String ext : extensionParts) {
             if (!isCaseSensitive() && ext.equalsIgnoreCase(refExtension)) {
                 return getOnMatch() == OnMatch.INCLUDE;
             } else if (isCaseSensitive() && ext.equals(refExtension)) {

--- a/norconex-collector-core/src/test/java/com/norconex/collector/core/filter/impl/ExtensionReferenceFilterTest.java
+++ b/norconex-collector-core/src/test/java/com/norconex/collector/core/filter/impl/ExtensionReferenceFilterTest.java
@@ -1,0 +1,39 @@
+package com.norconex.collector.core.filter.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExtensionReferenceFilterTest {
+
+    @Test
+    public void testOnlyDetectExtensionsInLastPathSegment() {
+        ExtensionReferenceFilter filter = initFilter("com,subtype.xml");
+
+        Assert.assertFalse(
+                filter.acceptReference("http://example.com"));
+
+        Assert.assertFalse(
+                filter.acceptReference("http://example.com/file"));
+
+        Assert.assertFalse(
+                filter.acceptReference("http://example.com/dir.com/file"));
+
+        Assert.assertTrue(
+                filter.acceptReference("http://example.com/file.com"));
+
+        Assert.assertTrue(
+                filter.acceptReference("http://example.de/file.com"));
+
+        Assert.assertFalse(
+                filter.acceptReference("http://example.com/file.xml"));
+
+        Assert.assertTrue(
+                filter.acceptReference("http://example.com/file.subtype.xml"));
+    }
+
+    private ExtensionReferenceFilter initFilter(String extensions) {
+        ExtensionReferenceFilter filter = new ExtensionReferenceFilter();
+        filter.setExtensions(extensions);
+        return filter;
+    }
+}


### PR DESCRIPTION
Previously. a reference such as `http://example.com/some.dir/file` would have matched a `dir/file` extension. Furthermore, extensions were looked for in the entire URL. For example,

``` xml
  <referenceFilters>
    <filter
      class="${filterExtension}"
      onMatch="exclude"
      caseSensitive="false"
    >com</filter>
  </referenceFilters>
  […]
  <startUrls>
    <url>http://example.com</url>
  </startUrl>
```

Would have meant that the crawl immediately finishes as `http://example.com` would have matched the `.com` exclusion pattern.

This patch makes three changes to fix the extension filtering behaviour:
1. Extensions are only taken into account when they occur within the _path_ of the full reference URL.
2. Extensions must occur _at the end_ of  the path.
3. Extensions must _only contain (ASCII) letters, digits, and dots_. (The latter allowing for `example.subtype.xml`-style filenames.)

This fixes #2.
