### PR TITLE
Introduce "maxParallelCrawlers" option in collector-config

### DIFF
--- a/norconex-collector-core/pom.xml
+++ b/norconex-collector-core/pom.xml
@@ -255,7 +255,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.2</version>
+        <version>3.1.0</version>
         <configuration>
           <overview>${basedir}/src/main/javadoc/overview.html</overview>
           <show>protected</show>

--- a/norconex-collector-core/src/main/java/com/norconex/collector/core/AbstractCollector.java
+++ b/norconex-collector-core/src/main/java/com/norconex/collector/core/AbstractCollector.java
@@ -204,7 +204,7 @@ public abstract class AbstractCollector implements ICollector {
         IJob rootJob = null;
         if (crawlers.length > 1) {
             rootJob = new AsyncJobGroup(
-                    getId(), crawlers
+                    getId(), getCollectorConfig().getMaxParallelCrawlers(), crawlers
             );
         } else if (crawlers.length == 1) {
             rootJob = crawlers[0];

--- a/norconex-collector-core/src/main/java/com/norconex/collector/core/AbstractCollectorConfig.java
+++ b/norconex-collector-core/src/main/java/com/norconex/collector/core/AbstractCollectorConfig.java
@@ -64,6 +64,7 @@ public abstract class AbstractCollectorConfig implements ICollectorConfig {
     private ICrawlerConfig[] crawlerConfigs;
     private String progressDir = DEFAULT_PROGRESS_DIR;
     private String logsDir = DEFAULT_LOGS_DIR;
+    private int maxParallelCrawlers = Integer.MAX_VALUE;
     private ICollectorLifeCycleListener[] collectorListeners;
     private IJobLifeCycleListener[] jobLifeCycleListeners;
     private IJobErrorListener[] jobErrorListeners;
@@ -153,7 +154,25 @@ public abstract class AbstractCollectorConfig implements ICollectorConfig {
         this.logsDir = logsDir;
     }
 
-    @Override    
+
+    /**
+     * Gets the value, how much crawlers should be executed in parallel
+     * @return how much crawlers should be executed in parallel
+     */
+    @Override
+    public int getMaxParallelCrawlers() {
+        return maxParallelCrawlers;
+    }
+
+    /**
+     *  set the number of max parallel executed crawlers
+     * @param maxParallelCrawlers   max parallel executed crawlers
+     */
+    public void setMaxParallelCrawlers(int maxParallelCrawlers) {
+        this.maxParallelCrawlers = maxParallelCrawlers;
+    }
+
+    @Override
     public ICollectorLifeCycleListener[] getCollectorListeners() {
         return collectorListeners;
     }
@@ -229,6 +248,7 @@ public abstract class AbstractCollectorConfig implements ICollectorConfig {
             
             writer.writeElementString("logsDir", getLogsDir());
             writer.writeElementString("progressDir", getProgressDir());
+            writer.writeElementInteger("maxParallelCrawlers", getMaxParallelCrawlers());
             writer.flush();
 
             writeArray(out, "collectorListeners", 
@@ -274,7 +294,8 @@ public abstract class AbstractCollectorConfig implements ICollectorConfig {
         setId(collectorId);
         setLogsDir(xml.getString("logsDir", getLogsDir()));
         setProgressDir(xml.getString("progressDir", getProgressDir()));
-        
+        setMaxParallelCrawlers(xml.getInt("maxParallelCrawlers", Integer.MAX_VALUE));
+
         // Collector listeners
         ICollectorLifeCycleListener[] collListeners = loadCollectorListeners(
                 xml, "collectorListeners.listener");

--- a/norconex-collector-core/src/main/java/com/norconex/collector/core/AbstractCollectorConfig.xsd
+++ b/norconex-collector-core/src/main/java/com/norconex/collector/core/AbstractCollectorConfig.xsd
@@ -22,6 +22,8 @@
                     type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element name="logsDir" 
                     type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="maxParallelCrawlers"
+                    type="xs:int" minOccurs="0" maxOccurs="1"/>
         <xs:element name="collectorListeners"
                     type="listenersType" minOccurs="0" maxOccurs="1"/>
         <xs:element name="jobLifeCycleListeners"

--- a/norconex-collector-core/src/main/java/com/norconex/collector/core/ICollectorConfig.java
+++ b/norconex-collector-core/src/main/java/com/norconex/collector/core/ICollectorConfig.java
@@ -90,4 +90,10 @@ public interface ICollectorConfig extends IXMLConfigurable {
      */
     ICrawlerConfig[] getCrawlerConfigs();
 
+    /**
+     * Gets the value, how much crawlers should be executed in parallel
+     * @return how much crawlers should be executed in parallel
+     * @since 1.9.2
+     */
+    int getMaxParallelCrawlers();
 }

--- a/norconex-collector-core/src/test/java/com/norconex/collector/core/AbstractCollectorTest.java
+++ b/norconex-collector-core/src/test/java/com/norconex/collector/core/AbstractCollectorTest.java
@@ -48,6 +48,7 @@ public class AbstractCollectorTest {
         config.setJobErrorListeners(new MockJobErrorListener());
         config.setJobLifeCycleListeners(new MockJobLifeCycleListener());
         config.setSuiteLifeCycleListeners(new MockSuiteLifeCycleListener());
+        config.setMaxParallelCrawlers(100);
         
         MockCrawlerConfig crawlerCfg = new MockCrawlerConfig();
         crawlerCfg.setId("myCrawler");

--- a/norconex-collector-core/src/test/resources/validation/collector-core-full.xml
+++ b/norconex-collector-core/src/test/resources/validation/collector-core-full.xml
@@ -24,6 +24,8 @@
   <progressDir>/progress</progressDir>
   <logsDir>/logs</logsDir>
 
+  <maxParallelCrawlers>50</maxParallelCrawlers>
+
   <collectorListeners>
     <listener class="com.norconex.collector.core.MockCollectorLifeCycleListener">
       <sample sample="sample">sample</sample>


### PR DESCRIPTION
… in order to configure size of threadpool that is used for parallel crawler jobs: pass it from AbstractCollector to already existing 2nd AsyncJobGroup constructor

We are using one collector with over 300 crawlers and are observing OutOfMemoryErrors if all are running in parallel alltogether (what currently is the only option).

Using this configuration option allows for a finer control over the consumed resources.
The behaviour is backward compatible: if the option is ommited, it is still all crawlers that are executed in parallel.