### PR TITLE
Remember Bad Status and Error to use Grace Once

### DIFF
--- a/norconex-collector-core/src/main/java/com/norconex/collector/core/data/store/impl/mvstore/MVStoreCrawlDataStore.java
+++ b/norconex-collector-core/src/main/java/com/norconex/collector/core/data/store/impl/mvstore/MVStoreCrawlDataStore.java
@@ -119,8 +119,14 @@ public class MVStoreCrawlDataStore extends AbstractCrawlDataStore {
             mapCached.clear();
             mapActive.clear();
             mapQueued.clear();
-            mapProcessedInvalid.clear();
-
+            
+            // Invalid Processed -> Cached
+            for (String key : datastoreMap.get(Name.processedInvalid).keySet()) {
+                ICrawlData processedInvalid = datastoreMap.get(Name.processedInvalid).remove(key);
+                if (processedInvalid.getState().isOneOf(CrawlState.ERROR, CrawlState.BAD_STATUS)) {
+                    datastoreMap.get(Name.cached).put(key, processedInvalid);
+                }
+            }
             // Valid Processed -> Cached
             for (String key : mapProcessedValid.keySet()) {
                 ICrawlData processed = mapProcessedValid.remove(key);

--- a/norconex-collector-core/src/main/java/com/norconex/collector/core/data/store/impl/mvstore/MVStoreCrawlDataStore.java
+++ b/norconex-collector-core/src/main/java/com/norconex/collector/core/data/store/impl/mvstore/MVStoreCrawlDataStore.java
@@ -123,7 +123,7 @@ public class MVStoreCrawlDataStore extends AbstractCrawlDataStore {
             // Invalid Processed -> Cached
             for (String key : datastoreMap.get(Name.processedInvalid).keySet()) {
                 ICrawlData processedInvalid = datastoreMap.get(Name.processedInvalid).remove(key);
-                if (processedInvalid.getState().isOneOf(CrawlState.ERROR, CrawlState.BAD_STATUS)) {
+                if (processedInvalid.getState().isOneOf(CrawlState.ERROR, CrawlState.BAD_STATUS, CrawlState.NOT_FOUND)) {
                     datastoreMap.get(Name.cached).put(key, processedInvalid);
                 }
             }


### PR DESCRIPTION
without this changes, grance once is not available, especially for errors. example:
Website A has a link to B. The Website crashes and the SpoiledReferenceStrategy is GRACE_ONCE.
200 ok crawl: A and B are committed
First error crawl, the cache is filled with A and B: A has an error and B has an error.
Second error crawl: without the change, the cache is empty, but:
- A is a Start-URL, so it is crawled and deleted, because of some bug-fix on AbstractCrawler line 694
- B is not in the cache, but was committed, is never deleted and is unknown forever

With this fix, the AbstractCrawler line 694 is not nessessary anymore, but its also not wrong.